### PR TITLE
Feat/openweather api 연동#5

### DIFF
--- a/.github/workflows/weather.yaml
+++ b/.github/workflows/weather.yaml
@@ -24,4 +24,5 @@ jobs:
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          OPENWEATHER_API_KEY: ${{ secrets.OPENWEATHER_API_KEY }}
         run: python3 main.py

--- a/main.py
+++ b/main.py
@@ -5,6 +5,8 @@ from dotenv import load_dotenv
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
+import weather
+
 # 환경 변수에서 Slack 토큰을 로드
 load_dotenv()
 
@@ -25,10 +27,22 @@ def main():
     date_of_today = current_time_kst.format(date_format, locale="ko_kr")
     
     # 메시지 제목
-    header = f"*[{date_of_today} 인증 스레드]*"
+    header = f"*[{date_of_today} 인증 스레드]*\n"
+
+    # 날씨 정보
+    weather_msg = ""
+    response_json = weather.fetch_data_from_openweather_api()
+    if (response_json == {}):
+        weather_msg = "날씨 정보를 가져오지 못했습니다. 😢"
+    else:
+        weather_data = weather.parse_weather_data(response_json)
+        weather_msg = f"오늘의 날씨: {weather_data['description']}\n- ⬇️최저 기온: {weather_data['min_temp']}°C\n- ⬆️최고 기온: {weather_data['max_temp']}°C\n- 💦습도: {weather_data['humidity']}%\n- 🌬️풍속: {weather_data['wind']}m/s\n- 🔎관측 지점: 서울 종로구"
+
+    # 메시지 본문
+    body = header + weather_msg
 
     # 슬랙 채널에 전송
-    send_slack_message(header)
+    send_slack_message(body)
 
 if __name__ == "__main__":
     main()

--- a/weather.py
+++ b/weather.py
@@ -1,0 +1,44 @@
+import requests
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OPENWEATHER_API_KEY = os.environ.get("OPENWEATHER_API_KEY")
+
+lang = "kr"
+units = "metric" # 온도 표시 단위(Celsius)
+
+# 서울 종로구 좌표
+lat = "37.5683"
+lon = "126.9778"
+
+api_url = f"https://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&units={units}&lang={lang}&appid={OPENWEATHER_API_KEY}"
+
+def fetch_data_from_openweather_api():
+    try:
+        response = requests.get(api_url)
+        response.raise_for_status()
+        data = response.json()
+
+        return data
+    except requests.exceptions.HTTPError as errh:
+        print(f"HTTP Error: {errh}")
+    except requests.exceptions.ConnectionError as errc:
+        print(f"Error Connecting: {errc}")
+    except requests.exceptions.Timeout as errt:
+        print(f"Timeout Error: {errt}")
+    except requests.exceptions.RequestException as err:
+        print(f"Something went wrong: {err}")
+    return {}
+
+def parse_weather_data(json):
+    data = {
+        'description': json['weather'][0]['description'],
+        'min_temp': json['main']['temp_min'],
+        'max_temp': json['main']['temp_max'],
+        'humidity': json['main']['humidity'],
+        'wind': json['wind']['speed'],
+    }
+    return data


### PR DESCRIPTION
# 이슈
- 기상청 단기예보 API 를 사용하려다가 결국 openweather API 를 사용했습니다.
- 각각 API 의 장단점을 비교하면 아래와 같습니다.

|서비스|장점|단점|
|------|---|---|
|기상청 API|구, 동 단위로 지역 기상 예보 조회 가능|2년에 1번씩 주기적으로 API 키를 교체해주어야 하는 번거로움|
|||당일 최저 기온, 최고 기온을 조회하려면 API 호출을 2번 해야 함|
|openweather|API 요청 1번만 보내면 최저, 최고 기온, 습도 등 모든 정보를 한 번에 조회 가능|구, 동 단위로 기상 예보 조회 불가|

- 기상청 API 키를 교체해주지 않으면 사용할 수 없기 때문에 지속가능한 서비스 운영 관점에서는 openweather API 를 사용하는 것이 좋다고 판단했습니다.
- openweather API 는 기상청 API 에 비해 구체적이고 자세한 정보를 제공하지는 않지만, 서비스의 목적이 구체적인 날씨 정보 제공이 아닌 대략적인 날씨 정보 제공이기 때문에 기상청 API 를 사용해야 할 이유가 크지 않다고 생각했습니다.