### PR TITLE
Feat/기상청 api 연동#7

### DIFF
--- a/.github/workflows/weather.yaml
+++ b/.github/workflows/weather.yaml
@@ -24,5 +24,5 @@ jobs:
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
-          OPENWEATHER_API_KEY: ${{ secrets.OPENWEATHER_API_KEY }}
+          SERVICE_KEY: ${{ secrets.SERVICE_KEY }}
         run: python3 main.py

--- a/main.py
+++ b/main.py
@@ -13,6 +13,20 @@ load_dotenv()
 SLACK_TOKEN = os.environ.get("SLACK_TOKEN")
 SLACK_CHANNEL = os.environ.get("SLACK_CHANNEL") # 여기에 메시지를 보낼 Slack 채널 이름을 입력하세요.
 
+STATUS_OF_SKY = {
+    '1': '맑음 ☀️',
+    '3': '구름많음 ☁️',
+    '4': '흐림 ⛅️',
+}
+
+STATUS_OF_PRECIPITATION = {
+    '0': '없음',
+    '1': '비 🌧️',
+    '2': '비/눈 🌨️',
+    '3': '눈 ❄️',
+    '4': '소나기 ☔️'
+}
+
 def send_slack_message(message):
     try:
         client = WebClient(token=SLACK_TOKEN)
@@ -31,12 +45,22 @@ def main():
 
     # 날씨 정보
     weather_msg = ""
-    response_json = weather.fetch_data_from_openweather_api()
-    if (response_json == {}):
+    sky = weather.fetch_data_from_kma(current_time_kst, '3', 'SKY', '0500')
+    precipitation = weather.fetch_data_from_kma(current_time_kst, '4', 'PTY', '0500')
+    lowest_temp_of_today = weather.fetch_data_from_kma(current_time_kst, '5', 'TMN', '0600')
+    highest_temp_of_today = weather.fetch_data_from_kma(current_time_kst, '16', 'TMX', '1500')
+
+    if (sky == None or precipitation == None or 
+        lowest_temp_of_today == None or highest_temp_of_today == None):
         weather_msg = "날씨 정보를 가져오지 못했습니다. 😢"
     else:
-        weather_data = weather.parse_weather_data(response_json)
-        weather_msg = f"오늘의 날씨: {weather_data['description']}\n- ⬇️최저 기온: {weather_data['min_temp']}°C\n- ⬆️최고 기온: {weather_data['max_temp']}°C\n- 💦습도: {weather_data['humidity']}%\n- 🌬️풍속: {weather_data['wind']}m/s\n- 🔎관측 지점: 서울 종로구"
+        weather_of_today = f"{STATUS_OF_SKY[sky]} (강수: {STATUS_OF_PRECIPITATION[precipitation]})"
+        weather_msg = (
+            f"🌏 현재 날씨: {weather_of_today}\n"
+            f"🔼 최고 기온: {highest_temp_of_today}°C\n"
+            f"🔽 최저 기온: {lowest_temp_of_today}°C\n"
+            f"🔎 관측 지점: 서울 강남구 개포2동"
+        )
 
     # 메시지 본문
     body = header + weather_msg


### PR DESCRIPTION
# 요약
- 아래와 같이 메세지 형식을 변경했습니다.
```
[2023년 12월 24일 일요일 인증 스레드]
🌏 현재 날씨: 흐림 ⛅️ (강수: 눈 ❄️)
🔼 최고 기온: 2.0°C
🔽 최저 기온: -5.0°C
🔎 관측 지점: 서울 강남구 개포2동
```
- OpenWeather API 에서 공공데이터포털에서 제공하는 기상청 API 를 사용했습니다. 
- 기상청 API 를 이용함으로써 구체적인 지역의 날씨 정보를 가져왔습니다.
- 날씨 정보는 당일 새벽 2시에 발표된 것을 기준으로 합니다.
- `현재 날씨` 와 `강수`는 새벽 5시를 기준으로 합니다.
- `최저 기온` 은 오전 6시를 기준으로 합니다.
- `최고 기온` 은 오후 3시를 기준으로 합니다.

# 작업 중 발견한 이슈
- `request.get()` 함수에 uri 쿼리문에 해당하는 params 를 넘길 때, encoding 상태의 문자열이 아닌 decoding 상태의 문자열을 넣어줘야 합니다. 
- 예를 들면, 문자열 `ApiKey%3D` 을 넣어주면 `%` 를 다시 한번 encoding 하기 때문에 `%` 는 `%25` 로 변환됩니다.
- `%3D` 는 `=` 에 해당하는데, 기상청에서 발급받은 `serviceKey` 는 decoding 인증키를 사용해야 합니다.